### PR TITLE
ci: align CodeQL workflow with dbus-btbattery repo

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,26 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       security-events: write
-      contents: read
-
     strategy:
-      fail-fast: false
       matrix:
         language: [python]
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
-
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
-        with:
-          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

- Remove extra Autobuild step and `contents: read` permission
- Remove `fail-fast` and `category` options
- Match lean CodeQL config from dbus-btbattery repo

Fixes #1