### PR TITLE
fix: correct installer paths and patching for actual VenusOS gui-v2 layout

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,6 @@ INSTALL_DIR="/data/venus-btbattery-gui"
 RC_LOCAL="/data/rc.local"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RC_MARKER="# venus-btbattery-gui"
-PAGE_NAME="PageBatteryParallelOverview"
 
 echo "=== venus-btbattery-gui installer ==="
 echo ""
@@ -23,8 +22,7 @@ else
     exit 1
 fi
 
-GUI_QML_DIR="$GUI_V2_DIR/pages"
-GUI_COMPONENTS_DIR="$GUI_V2_DIR/components"
+GUI_COMPONENTS_DIR="$GUI_V2_DIR/Victron/VenusOS/components"
 SWIPE_MODEL="$GUI_COMPONENTS_DIR/SwipePageModel.qml"
 
 # Log gui-v2 version for troubleshooting
@@ -44,111 +42,101 @@ fi
 # Copy files to /data (persists across firmware upgrades)
 echo "Installing to $INSTALL_DIR..."
 mkdir -p "$INSTALL_DIR/qml"
-mkdir -p "$INSTALL_DIR/tools"
 cp "$SCRIPT_DIR/config.ini" "$INSTALL_DIR/"
 cp "$SCRIPT_DIR/qml/"*.qml "$INSTALL_DIR/qml/"
 cp "$SCRIPT_DIR/install.sh" "$INSTALL_DIR/"
 cp "$SCRIPT_DIR/uninstall.sh" "$INSTALL_DIR/"
 
-# Create symlinks for QML files into gui-v2 pages directory
-echo "Creating QML symlinks in gui-v2..."
-for qmlfile in "$INSTALL_DIR/qml/"*.qml; do
-    filename=$(basename "$qmlfile")
-    ln -sf "$qmlfile" "$GUI_QML_DIR/$filename" 2>/dev/null || \
-    ln -sf "$qmlfile" "$GUI_COMPONENTS_DIR/$filename" 2>/dev/null || true
-done
+# Write the SwipePageModel patch script
+cat > "$INSTALL_DIR/patch_swipe_model.py" << 'PYEOF'
+#!/usr/bin/env python3
+"""Patches SwipePageModel.qml to load PageBatteryParallelOverview into the carousel."""
+import sys, os
 
-# Patch SwipePageModel.qml to add our page to the carousel
-patch_swipe_model() {
-    local swipe_model="$1"
-    if [ ! -f "$swipe_model" ]; then
-        echo "WARNING: SwipePageModel.qml not found at $swipe_model"
-        echo "Page will not appear in carousel. Manual integration needed."
-        return 1
-    fi
+swipe_model = sys.argv[1] if len(sys.argv) > 1 else \
+    "/opt/victronenergy/gui-v2/Victron/VenusOS/components/SwipePageModel.qml"
 
-    # Check if already patched
-    if grep -q "$PAGE_NAME" "$swipe_model"; then
-        echo "SwipePageModel.qml already contains $PAGE_NAME entry."
-        return 0
-    fi
+marker = "// venus-btbattery-gui"
+insert_code = (
+    "    // venus-btbattery-gui\n"
+    "    var btBatComp = Qt.createComponent("
+        '"file:///data/venus-btbattery-gui/qml/PageBatteryParallelOverview.qml")\n'
+    "    if (btBatComp.status === Component.Ready) {\n"
+    "        insert(count - 1, btBatComp.createObject(parent, {view: root.view}))\n"
+    "    }\n"
+    "    // venus-btbattery-gui END\n"
+    "\n"
+)
+anchor = "        completed = true"
 
-    # Back up original
-    cp "$swipe_model" "$INSTALL_DIR/SwipePageModel.qml.orig"
+if not os.path.exists(swipe_model):
+    print("ERROR: {} not found".format(swipe_model))
+    sys.exit(1)
 
-    # Find the last SwipeViewPage entry and add ours after it
-    # We insert before the closing brace of the ObjectModel
-    sed -i "/^[[:space:]]*}[[:space:]]*\/\/[[:space:]]*end[[:space:]]*ObjectModel\|^[[:space:]]*}[[:space:]]*$/,\${
-        /^[[:space:]]*}/ {
-            i\\
-\\        // $RC_MARKER\\
-\\        SwipeViewPage {\\
-\\            navButtonText: \"Batteries\"\\
-\\            navButtonIcon: \"qrc:///images/icon_battery_24.svg\"\\
-\\            url: \"file://$INSTALL_DIR/qml/$PAGE_NAME.qml\"\\
-\\        }
-            b
-        }
-    }" "$swipe_model"
+with open(swipe_model) as f:
+    content = f.read()
 
-    # Verify patch applied
-    if grep -q "$PAGE_NAME" "$swipe_model"; then
-        echo "SwipePageModel.qml patched successfully."
-        return 0
-    else
-        echo "WARNING: Failed to patch SwipePageModel.qml automatically."
-        echo "Restoring backup..."
-        cp "$INSTALL_DIR/SwipePageModel.qml.orig" "$swipe_model"
-        echo "Manual integration needed. Add a SwipeViewPage entry for $PAGE_NAME."
-        return 1
-    fi
-}
+if marker in content:
+    print("SwipePageModel.qml already patched.")
+    sys.exit(0)
 
-patch_swipe_model "$SWIPE_MODEL"
+if anchor not in content:
+    print("ERROR: insertion point not found in SwipePageModel.qml")
+    sys.exit(1)
 
-# Set up rc.local for firmware upgrade persistence
-echo "Configuring rc.local for boot persistence..."
+content = content.replace(anchor, insert_code + anchor, 1)
+with open(swipe_model, "w") as f:
+    f.write(content)
+print("SwipePageModel.qml patched.")
+PYEOF
 
-# Ensure rc.local exists and is executable
+# Patch SwipePageModel.qml
+echo "Patching SwipePageModel.qml..."
+if [ ! -f "$SWIPE_MODEL" ]; then
+    echo "ERROR: $SWIPE_MODEL not found"
+    exit 1
+fi
+
+if [ ! -f "$INSTALL_DIR/SwipePageModel.qml.orig" ]; then
+    cp "$SWIPE_MODEL" "$INSTALL_DIR/SwipePageModel.qml.orig"
+    echo "Backed up original SwipePageModel.qml"
+fi
+
+python3 "$INSTALL_DIR/patch_swipe_model.py" "$SWIPE_MODEL"
+
+# Update rc.local for firmware upgrade persistence
+echo "Updating rc.local..."
 touch "$RC_LOCAL"
 chmod +x "$RC_LOCAL"
 
-# Add shebang if missing
-if ! head -1 "$RC_LOCAL" | grep -q "^#!"; then
-    sed -i '1i#!/bin/bash' "$RC_LOCAL"
-fi
-
-# Remove old entry if present
-if grep -q "$RC_MARKER" "$RC_LOCAL"; then
-    sed -i "/$RC_MARKER/,/^$RC_MARKER END/d" "$RC_LOCAL"
-fi
+# Remove existing venus-btbattery-gui block and ensure shebang, using Python
+python3 - << 'PYEOF'
+import re
+path = '/data/rc.local'
+with open(path) as f:
+    content = f.read()
+# Remove old block if present
+content = re.sub(
+    r'\n# venus-btbattery-gui\n.*?# venus-btbattery-gui END\n',
+    '',
+    content,
+    flags=re.DOTALL
+)
+# Ensure shebang
+if not content.startswith('#!'):
+    content = '#!/bin/bash\n' + content
+with open(path, 'w') as f:
+    f.write(content)
+PYEOF
 
 cat >> "$RC_LOCAL" << RCEOF
 
 $RC_MARKER
-# Re-establish QML symlinks and SwipePageModel patch after firmware upgrade
-if [ -d "$GUI_V2_DIR" ] && [ -d "$INSTALL_DIR" ]; then
-    # Symlink QML files
-    for qmlfile in $INSTALL_DIR/qml/*.qml; do
-        filename=\$(basename "\$qmlfile")
-        ln -sf "\$qmlfile" "$GUI_QML_DIR/\$filename" 2>/dev/null || true
-    done
-    # Patch SwipePageModel if needed
-    SWIPE_MODEL="$SWIPE_MODEL"
-    if [ -f "\$SWIPE_MODEL" ] && ! grep -q "$PAGE_NAME" "\$SWIPE_MODEL"; then
-        cp "\$SWIPE_MODEL" "$INSTALL_DIR/SwipePageModel.qml.orig"
-        # Simple append before last closing brace
-        sed -i "/^[[:space:]]*}[[:space:]]*$/,\\\${ /^[[:space:]]*}/ {
-            i\\\\
-\\\\        // $RC_MARKER\\\\
-\\\\        SwipeViewPage {\\\\
-\\\\            navButtonText: \\\"Batteries\\\"\\\\
-\\\\            navButtonIcon: \\\"qrc:///images/icon_battery_24.svg\\\"\\\\
-\\\\            url: \\\"file://$INSTALL_DIR/qml/$PAGE_NAME.qml\\\"\\\\
-\\\\        }
-            b
-        }}" "\$SWIPE_MODEL"
-    fi
+# Re-apply SwipePageModel.qml patch after firmware upgrade
+SWIPE_MODEL="$SWIPE_MODEL"
+INSTALL_DIR="$INSTALL_DIR"
+if [ -f "\$INSTALL_DIR/patch_swipe_model.py" ] && [ -f "\$SWIPE_MODEL" ]; then
+    python3 "\$INSTALL_DIR/patch_swipe_model.py" "\$SWIPE_MODEL"
 fi
 $RC_MARKER END
 RCEOF
@@ -156,10 +144,10 @@ RCEOF
 echo "rc.local updated."
 
 # Restart GUI
-echo "Restarting GUI service..."
-svc -t /service/gui 2>/dev/null || echo "Note: GUI service restart skipped (not running on VenusOS)"
+echo "Restarting GUI..."
+svc -t /service/gui 2>/dev/null || echo "Note: GUI restart skipped (not on VenusOS)."
 
 echo ""
 echo "=== Installation complete ==="
 echo "Config: $INSTALL_DIR/config.ini"
-echo "To uninstall: $INSTALL_DIR/uninstall.sh"
+echo "Uninstall: bash $INSTALL_DIR/uninstall.sh"

--- a/qml/PageBatteryParallelOverview.qml
+++ b/qml/PageBatteryParallelOverview.qml
@@ -7,6 +7,9 @@ Rectangle {
     height: 480
     color: "#1a1a2e"
 
+    // Accepted by SwipePageModel (unused, but required to avoid binding error)
+    property var view
+
     // Config properties (loaded from config.ini)
     property int socColorGreen: 60
     property int socColorYellow: 20

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -2,62 +2,82 @@
 set -e
 
 INSTALL_DIR="/data/venus-btbattery-gui"
-GUI_V2_DIR="/opt/victronenergy/gui-v2"
-GUI_QML_DIR="$GUI_V2_DIR/pages"
-GUI_COMPONENTS_DIR="$GUI_V2_DIR/components"
-SWIPE_MODEL="$GUI_COMPONENTS_DIR/SwipePageModel.qml"
 RC_LOCAL="/data/rc.local"
-RC_MARKER="# venus-btbattery-gui"
-PAGE_NAME="PageBatteryParallelOverview"
 
 echo "=== venus-btbattery-gui uninstaller ==="
 echo ""
 
-# Remove QML symlinks
-echo "Removing QML symlinks..."
-for dir in "$GUI_QML_DIR" "$GUI_COMPONENTS_DIR"; do
-    if ls "$INSTALL_DIR/qml/"*.qml >/dev/null 2>&1; then
-        for qmlfile in "$INSTALL_DIR/qml/"*.qml; do
-            filename=$(basename "$qmlfile")
-            if [ -L "$dir/$filename" ]; then
-                rm "$dir/$filename"
-                echo "  Removed: $dir/$filename"
-            fi
-        done
-    fi
-done
+# Locate gui-v2 (path differs between Cerbo GX and RPi4)
+if [ -d "/opt/victronenergy/gui-v2" ]; then
+    GUI_V2_DIR="/opt/victronenergy/gui-v2"
+elif [ -d "/var/www/venus/gui-v2" ]; then
+    GUI_V2_DIR="/var/www/venus/gui-v2"
+else
+    GUI_V2_DIR=""
+fi
 
-# Restore SwipePageModel.qml from backup
-if [ -f "$INSTALL_DIR/SwipePageModel.qml.orig" ] && [ -f "$SWIPE_MODEL" ]; then
-    if grep -q "$PAGE_NAME" "$SWIPE_MODEL"; then
-        echo "Restoring original SwipePageModel.qml..."
+GUI_COMPONENTS_DIR="${GUI_V2_DIR:+$GUI_V2_DIR/Victron/VenusOS/components}"
+SWIPE_MODEL="${GUI_COMPONENTS_DIR:+$GUI_COMPONENTS_DIR/SwipePageModel.qml}"
+
+# Restore SwipePageModel.qml
+if [ -f "$SWIPE_MODEL" ] && grep -q "venus-btbattery-gui" "$SWIPE_MODEL" 2>/dev/null; then
+    if [ -f "$INSTALL_DIR/SwipePageModel.qml.orig" ]; then
+        echo "Restoring SwipePageModel.qml from backup..."
         cp "$INSTALL_DIR/SwipePageModel.qml.orig" "$SWIPE_MODEL"
+    else
+        echo "No backup found — removing patch from SwipePageModel.qml..."
+        python3 - "$SWIPE_MODEL" << 'PYEOF'
+import sys, re
+with open(sys.argv[1]) as f:
+    content = f.read()
+content = re.sub(
+    r'    // venus-btbattery-gui\n.*?    // venus-btbattery-gui END\n\n',
+    '',
+    content,
+    flags=re.DOTALL
+)
+with open(sys.argv[1], 'w') as f:
+    f.write(content)
+print("Patch removed.")
+PYEOF
     fi
-elif [ -f "$SWIPE_MODEL" ] && grep -q "$PAGE_NAME" "$SWIPE_MODEL"; then
-    echo "Removing patch from SwipePageModel.qml..."
-    sed -i "/$RC_MARKER/,/SwipeViewPage.*$PAGE_NAME.*}/d" "$SWIPE_MODEL"
 fi
 
 # Remove rc.local entry
-if [ -f "$RC_LOCAL" ] && grep -q "$RC_MARKER" "$RC_LOCAL"; then
+if [ -f "$RC_LOCAL" ] && grep -q "venus-btbattery-gui" "$RC_LOCAL" 2>/dev/null; then
     echo "Removing rc.local entry..."
-    sed -i "/$RC_MARKER/,/$RC_MARKER END/d" "$RC_LOCAL"
+    python3 - << 'PYEOF'
+import re
+with open('/data/rc.local') as f:
+    content = f.read()
+content = re.sub(
+    r'\n# venus-btbattery-gui\n.*?# venus-btbattery-gui END\n',
+    '',
+    content,
+    flags=re.DOTALL
+)
+with open('/data/rc.local', 'w') as f:
+    f.write(content)
+PYEOF
 fi
 
 # Ask about removing install directory
 echo ""
-read -p "Remove $INSTALL_DIR and all config? (y/N) " -n 1 -r
+read -rp "Remove $INSTALL_DIR and all config? (y/N) " REPLY
 echo ""
-if [[ $REPLY =~ ^[Yy]$ ]]; then
-    echo "Removing $INSTALL_DIR..."
-    rm -rf "$INSTALL_DIR"
-else
-    echo "Keeping $INSTALL_DIR (config preserved)."
-fi
+case "$REPLY" in
+    [Yy]*)
+        echo "Removing $INSTALL_DIR..."
+        rm -rf "$INSTALL_DIR"
+        ;;
+    *)
+        echo "Keeping $INSTALL_DIR (config preserved)."
+        ;;
+esac
 
 # Restart GUI
-echo "Restarting GUI service..."
-svc -t /service/gui 2>/dev/null || echo "Note: GUI service restart skipped (not running on VenusOS)"
+echo "Restarting GUI..."
+svc -t /service/gui 2>/dev/null || echo "Note: GUI restart skipped (not on VenusOS)."
 
 echo ""
 echo "=== Uninstall complete ==="


### PR DESCRIPTION
Closes #7

## Summary

- Fix `GUI_QML_DIR`/`GUI_COMPONENTS_DIR` to the real VenusOS path: `/opt/victronenergy/gui-v2/Victron/VenusOS/{pages,components}/`
- Replace symlink + sed approach with Python-based patching — `qmldir` explicitly registers all types so symlinks don't register custom types; BusyBox sed is too limited for multi-line patches
- Use `Qt.createComponent("file:///data/...")` in `SwipePageModel`'s `Component.onCompleted` to inject the page — same pattern as built-in `LevelsPage`/`BoatPage`
- Write `patch_swipe_model.py` to `/data/` for reliable re-application after firmware upgrades
- Use Python for `rc.local` management
- Add `property var view` to `PageBatteryParallelOverview.qml` to accept the binding without error

## Test plan

- [ ] SSH into Cerbo GX, clone/pull repo, run `bash install.sh`
- [ ] Verify `SwipePageModel.qml` contains the injected `Qt.createComponent` block
- [ ] Verify battery page appears in the carousel after GUI restart
- [ ] Run `bash /data/venus-btbattery-gui/uninstall.sh` and confirm clean removal
- [ ] Simulate firmware upgrade (restore original SwipePageModel) and verify rc.local re-applies patch on boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
