### PR TITLE
fix: use tabs as indentation anchor in SwipePageModel patch

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -58,16 +58,16 @@ swipe_model = sys.argv[1] if len(sys.argv) > 1 else \
 
 marker = "// venus-btbattery-gui"
 insert_code = (
-    "    // venus-btbattery-gui\n"
-    "    var btBatComp = Qt.createComponent("
+    "\t\t// venus-btbattery-gui\n"
+    "\t\tvar btBatComp = Qt.createComponent("
         '"file:///data/venus-btbattery-gui/qml/PageBatteryParallelOverview.qml")\n'
-    "    if (btBatComp.status === Component.Ready) {\n"
-    "        insert(count - 1, btBatComp.createObject(parent, {view: root.view}))\n"
-    "    }\n"
-    "    // venus-btbattery-gui END\n"
+    "\t\tif (btBatComp.status === Component.Ready) {\n"
+    "\t\t\tinsert(count - 1, btBatComp.createObject(parent, {view: root.view}))\n"
+    "\t\t}\n"
+    "\t\t// venus-btbattery-gui END\n"
     "\n"
 )
-anchor = "        completed = true"
+anchor = "\t\tcompleted = true"
 
 if not os.path.exists(swipe_model):
     print("ERROR: {} not found".format(swipe_model))


### PR DESCRIPTION
Closes #9

## Summary

- Change anchor from 8-space `"        completed = true"` to tab-indented `"\t\tcompleted = true"` to match actual VenusOS v3.71 file
- Update injected code block to use tabs for consistency with surrounding file

## Test plan

- [ ] Run `bash install.sh` on Cerbo GX (VenusOS v3.71) — should complete without error
- [ ] Verify battery page appears in carousel after GUI restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)