### PR TITLE
fix: handle uppercase MAC service names and no-separator format

### DIFF
--- a/qml/PageBatteryParallelOverview.qml
+++ b/qml/PageBatteryParallelOverview.qml
@@ -107,14 +107,18 @@ SwipeViewPage {
     }
 
     function extractMac(serviceName) {
-        var suffix = serviceName.replace("com.victronenergy.battery.bt", "")
-        return suffix.replace(/_/g, ":").toLowerCase()
+        var hex = serviceName.replace("com.victronenergy.battery.bt", "").toLowerCase()
+        // Service names have no separators (e.g. btA4C138332459) — insert colons
+        if (hex.indexOf(":") === -1 && hex.indexOf("_") === -1 && hex.length === 12)
+            return hex.match(/.{2}/g).join(":")
+        // Older format used underscores
+        return hex.replace(/_/g, ":")
     }
 
     function onBatteryServiceFound(serviceName) {
         if (serviceName === "com.victronenergy.battery.parallel") return
         if (discoveredServices[serviceName]) return
-        if (!serviceName.match(/\.bt[0-9a-f]/)) return
+        if (!serviceName.match(/\.bt[0-9a-fA-F]/)) return
         if (batteryModel.count >= maxBatteries) return
 
         var mac = extractMac(serviceName)


### PR DESCRIPTION
Closes #13

## Summary

- Fix regex `/\.bt[0-9a-f]/` → `/\.bt[0-9a-fA-F]/` to accept uppercase hex MAC digits
- Fix `extractMac` to insert colons every 2 chars for the `btA4C138332459` format (no separators), falling back to underscore replacement for older format

## Test plan

- [ ] Pull and re-run `bash install.sh` on Cerbo GX
- [ ] Battery page populates with all 4 batteries instead of "Discovering batteries..."
- [ ] SOC, voltage, current, temp display correctly per battery

🤖 Generated with [Claude Code](https://claude.com/claude-code)