### PR TITLE
fix: battery discovery — hardcode D-Bus UID, add onValidChanged, use Qt.resolvedUrl

### DIFF
--- a/qml/PageBatteryParallelOverview.qml
+++ b/qml/PageBatteryParallelOverview.qml
@@ -76,12 +76,18 @@ SwipeViewPage {
     // Strategy 1: Read system/Batteries list
     VeQuickItem {
         id: batteriesItem
-        uid: BackendConnection.serviceUidForType("system") + "/Batteries"
+        uid: "dbus/com.victronenergy.system/Batteries"
+        onValidChanged: {
+            if (valid && value) batteriesItem.processBatteries(value)
+        }
         onValueChanged: {
             if (!valid || !value) return
+            batteriesItem.processBatteries(value)
+        }
+        function processBatteries(val) {
             try {
                 // Value may be a JSON string or a native array
-                var batteries = typeof value === "string" ? JSON.parse(value) : value
+                var batteries = typeof val === "string" ? JSON.parse(val) : val
                 if (!Array.isArray(batteries)) return
                 for (var i = 0; i < batteries.length; i++) {
                     var bat = batteries[i]
@@ -155,7 +161,7 @@ SwipeViewPage {
         discoveredServices[serviceName] = true
 
         // Create binding component
-        var component = Qt.createComponent("BatteryBinding.qml")
+        var component = Qt.createComponent(Qt.resolvedUrl("BatteryBinding.qml"))
         if (component.status === Component.Ready) {
             var binding = component.createObject(root, {
                 serviceUid: serviceUid,
@@ -169,7 +175,7 @@ SwipeViewPage {
 
     function bindAggregate(serviceUid) {
         if (aggregateBinding) return
-        var component = Qt.createComponent("AggregateBinding.qml")
+        var component = Qt.createComponent(Qt.resolvedUrl("AggregateBinding.qml"))
         if (component.status === Component.Ready) {
             aggregateBinding = component.createObject(root, {
                 serviceUid: serviceUid


### PR DESCRIPTION
## Summary

- Hardcode `uid: "dbus/com.victronenergy.system/Batteries"` — `BackendConnection.serviceUidForType()` doesn't resolve correctly from a dynamically-loaded `file://` component
- Add `onValidChanged` to `batteriesItem` so discovery fires when the binding first becomes active, not just on subsequent value changes
- Use `Qt.resolvedUrl("BatteryBinding.qml")` and `Qt.resolvedUrl("AggregateBinding.qml")` so sub-component paths resolve correctly regardless of how the parent was loaded

## Test plan

- [ ] Install on Cerbo GX: `bash /data/venus-btbattery-gui/install.sh`
- [ ] Navigate to Battery page in carousel
- [ ] Verify batteries populate (no more "Discovering batteries...")
- [ ] Confirm SOC, voltage, current, temp, cell delta, cycles all show live values

Closes #15