### PR TITLE
fix: config loading, aggregate binding, layout and font improvements

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,6 +1,7 @@
 [GUI]
 # Map MAC addresses to display names (6 char max per name)
 # Format: MAC=Name pairs, comma-separated
+# Batteries render in the order listed here; unlisted batteries appended after
 # Example: 70:3e:97:08:00:62=Bat A,a4:c1:38:xx:xx:xx=Bat B
 BT_NAMES =
 
@@ -14,3 +15,20 @@ SOC_COLOR_RED = 10
 
 # Maximum number of batteries to display (1-8)
 MAX_BATTERIES = 8
+
+# Font sizes (pixels) and bold (true/false)
+# Battery name label
+FONT_BAT_NAME_SIZE = 13
+FONT_BAT_NAME_BOLD = true
+# Battery SOC percentage
+FONT_BAT_SOC_SIZE = 20
+FONT_BAT_SOC_BOLD = true
+# Battery stats (voltage, current, temp, cycles)
+FONT_BAT_STATS_SIZE = 14
+FONT_BAT_STATS_BOLD = false
+# Bank aggregate labels (BANK SOC, VOLTAGE, etc.)
+FONT_BANK_LABEL_SIZE = 10
+FONT_BANK_LABEL_BOLD = false
+# Bank aggregate values
+FONT_BANK_VALUE_SIZE = 18
+FONT_BANK_VALUE_BOLD = true

--- a/install.sh
+++ b/install.sh
@@ -90,6 +90,89 @@ with open(swipe_model, "w") as f:
 print("SwipePageModel.qml patched.")
 PYEOF
 
+# Generate ConfigData.qml from config.ini (workaround for XHR file:// being blocked)
+echo "Generating ConfigData.qml from config.ini..."
+python3 - "$INSTALL_DIR/config.ini" "$INSTALL_DIR/qml/ConfigData.qml" << 'PYEOF'
+import sys, re
+
+config_path = sys.argv[1]
+output_path = sys.argv[2]
+
+# Defaults
+vals = {
+    "socColorGreen": 60, "socColorYellow": 20, "socColorRed": 10,
+    "maxBatteries": 8,
+    "fontBatNameSize": 13, "fontBatNameBold": True,
+    "fontBatSocSize": 20, "fontBatSocBold": True,
+    "fontBatStatsSize": 14, "fontBatStatsBold": False,
+    "fontBankLabelSize": 10, "fontBankLabelBold": False,
+    "fontBankValueSize": 18, "fontBankValueBold": True,
+}
+bt_names = {}   # mac -> name
+bat_order = []  # macs in config order
+
+key_map = {
+    "SOC_COLOR_GREEN": ("socColorGreen", "int"),
+    "SOC_COLOR_YELLOW": ("socColorYellow", "int"),
+    "SOC_COLOR_RED": ("socColorRed", "int"),
+    "MAX_BATTERIES": ("maxBatteries", "int"),
+    "FONT_BAT_NAME_SIZE": ("fontBatNameSize", "int"),
+    "FONT_BAT_NAME_BOLD": ("fontBatNameBold", "bool"),
+    "FONT_BAT_SOC_SIZE": ("fontBatSocSize", "int"),
+    "FONT_BAT_SOC_BOLD": ("fontBatSocBold", "bool"),
+    "FONT_BAT_STATS_SIZE": ("fontBatStatsSize", "int"),
+    "FONT_BAT_STATS_BOLD": ("fontBatStatsBold", "bool"),
+    "FONT_BANK_LABEL_SIZE": ("fontBankLabelSize", "int"),
+    "FONT_BANK_LABEL_BOLD": ("fontBankLabelBold", "bool"),
+    "FONT_BANK_VALUE_SIZE": ("fontBankValueSize", "int"),
+    "FONT_BANK_VALUE_BOLD": ("fontBankValueBold", "bool"),
+}
+
+with open(config_path) as f:
+    for line in f:
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("[") or "=" not in line:
+            continue
+        key, val = line.split("=", 1)
+        key, val = key.strip(), val.strip()
+        if key == "BT_NAMES" and val:
+            for pair in val.split(","):
+                pair = pair.strip()
+                if "=" not in pair:
+                    continue
+                mac, name = pair.split("=", 1)
+                mac = mac.strip().lower()
+                name = name.strip()[:6]
+                bt_names[mac] = name
+                bat_order.append(mac)
+        elif key in key_map:
+            prop, typ = key_map[key]
+            if typ == "int":
+                vals[prop] = int(val)
+            elif typ == "bool":
+                vals[prop] = val.lower() in ("true", "1", "yes")
+
+# Generate QML
+lines = ["import QtQuick", "", "QtObject {"]
+for prop, val in vals.items():
+    if isinstance(val, bool):
+        lines.append("    property bool {}: {}".format(prop, "true" if val else "false"))
+    else:
+        lines.append("    property int {}: {}".format(prop, val))
+
+# Emit btNames as a JS object and batOrder as a list
+names_entries = ", ".join('"{}": "{}"'.format(m, n) for m, n in bt_names.items())
+lines.append("    property var btNames: ({{{}}})".format(names_entries))
+order_str = ", ".join('"{}"'.format(m) for m in bat_order)
+lines.append("    property var batOrder: [{}]".format(order_str))
+lines.append("}")
+lines.append("")
+
+with open(output_path, "w") as f:
+    f.write("\n".join(lines))
+print("ConfigData.qml generated.")
+PYEOF
+
 # Patch SwipePageModel.qml
 echo "Patching SwipePageModel.qml..."
 if [ ! -f "$SWIPE_MODEL" ]; then

--- a/qml/PageBatteryParallelOverview.qml
+++ b/qml/PageBatteryParallelOverview.qml
@@ -8,61 +8,50 @@ SwipeViewPage {
     navButtonIcon: "qrc:/images/icon_battery_24.svg"
     url: "file:///data/venus-btbattery-gui/qml/PageBatteryParallelOverview.qml"
 
-    // Config properties (loaded from config.ini)
+    // Config — loaded from generated ConfigData.qml
     property int socColorGreen: 60
     property int socColorYellow: 20
     property int socColorRed: 10
     property int maxBatteries: 8
-
-    // Config: MAC-to-name mapping
     property var nameMap: ({})   // MAC string -> display name
-    property var nameOrder: []   // MAC strings in config order
+    property var batOrder: []    // MAC strings in config order
+
+    // Font config
+    property int fontBatNameSize: 13
+    property bool fontBatNameBold: true
+    property int fontBatSocSize: 20
+    property bool fontBatSocBold: true
+    property int fontBatStatsSize: 14
+    property bool fontBatStatsBold: false
+    property int fontBankLabelSize: 10
+    property bool fontBankLabelBold: false
+    property int fontBankValueSize: 18
+    property bool fontBankValueBold: true
 
     Component.onCompleted: loadConfig()
 
     function loadConfig() {
-        var xhr = new XMLHttpRequest()
-        var configPath = "/data/venus-btbattery-gui/config.ini"
-        xhr.open("GET", "file://" + configPath, false)
-        xhr.send()
-
-        var text = xhr.responseText
-        if (!text || text.length === 0) {
-            xhr.open("GET", "../config.ini", false)
-            xhr.send()
-            text = xhr.responseText
-        }
-        if (!text) return
-
-        var lines = text.split("\n")
-        for (var i = 0; i < lines.length; i++) {
-            var line = lines[i].trim()
-            if (line.indexOf("#") === 0 || line.indexOf("[") === 0 || line.indexOf("=") === -1) continue
-
-            var eqIdx = line.indexOf("=")
-            var key = line.substring(0, eqIdx).trim()
-            var val = line.substring(eqIdx + 1).trim()
-
-            if (key === "SOC_COLOR_GREEN") socColorGreen = parseInt(val)
-            else if (key === "SOC_COLOR_YELLOW") socColorYellow = parseInt(val)
-            else if (key === "SOC_COLOR_RED") socColorRed = parseInt(val)
-            else if (key === "MAX_BATTERIES") maxBatteries = parseInt(val)
-            else if (key === "BT_NAMES" && val.length > 0) {
-                var pairs = val.split(",")
-                var map = {}
-                var order = []
-                for (var j = 0; j < pairs.length; j++) {
-                    var pair = pairs[j].trim()
-                    var sepIdx = pair.indexOf("=")
-                    if (sepIdx === -1) continue
-                    var mac = pair.substring(0, sepIdx).trim().toLowerCase()
-                    var name = pair.substring(sepIdx + 1).trim().substring(0, 6)
-                    map[mac] = name
-                    order.push(mac)
-                }
-                nameMap = map
-                nameOrder = order
-            }
+        var comp = Qt.createComponent(Qt.resolvedUrl("ConfigData.qml"))
+        if (comp.status === Component.Ready) {
+            var cfg = comp.createObject(root)
+            if (!cfg) return
+            socColorGreen = cfg.socColorGreen
+            socColorYellow = cfg.socColorYellow
+            socColorRed = cfg.socColorRed
+            maxBatteries = cfg.maxBatteries
+            nameMap = cfg.btNames || {}
+            batOrder = cfg.batOrder || []
+            fontBatNameSize = cfg.fontBatNameSize
+            fontBatNameBold = cfg.fontBatNameBold
+            fontBatSocSize = cfg.fontBatSocSize
+            fontBatSocBold = cfg.fontBatSocBold
+            fontBatStatsSize = cfg.fontBatStatsSize
+            fontBatStatsBold = cfg.fontBatStatsBold
+            fontBankLabelSize = cfg.fontBankLabelSize
+            fontBankLabelBold = cfg.fontBankLabelBold
+            fontBankValueSize = cfg.fontBankValueSize
+            fontBankValueBold = cfg.fontBankValueBold
+            cfg.destroy()
         }
     }
 
@@ -73,7 +62,6 @@ SwipeViewPage {
     property var aggregateBinding: null
 
     // Watch for battery services on D-Bus
-    // Strategy 1: Read system/Batteries list
     VeQuickItem {
         id: batteriesItem
         uid: "dbus/com.victronenergy.system/Batteries"
@@ -86,14 +74,14 @@ SwipeViewPage {
         }
         function processBatteries(val) {
             try {
-                // Value may be a JSON string or a native array
                 var batteries = typeof val === "string" ? JSON.parse(val) : val
-                if (!Array.isArray(batteries)) return
+                if (!batteries || !batteries.length) return
                 for (var i = 0; i < batteries.length; i++) {
                     var bat = batteries[i]
-                    // Handle both object format {id:"svc"} and string format "svc"
                     var svcName = typeof bat === "string" ? bat : (bat.id || bat.service || bat.name || "")
-                    if (svcName.indexOf("com.victronenergy.battery.") === 0) {
+                    if (svcName === "com.victronenergy.battery.parallel") {
+                        root.bindAggregate("dbus/" + svcName)
+                    } else if (svcName.indexOf("com.victronenergy.battery.") === 0) {
                         root.onBatteryServiceFound(svcName)
                     }
                 }
@@ -103,10 +91,10 @@ SwipeViewPage {
         }
     }
 
-    // Also watch for the parallel aggregate service directly
+    // Fallback: watch for the parallel aggregate service directly
     VeQuickItem {
         id: parallelCheck
-        uid: "dbus/com.victronenergy.battery.parallel/ProductName"
+        uid: "dbus/com.victronenergy.battery.parallel/Soc"
         onValidChanged: {
             if (valid) root.bindAggregate("dbus/com.victronenergy.battery.parallel")
         }
@@ -114,10 +102,8 @@ SwipeViewPage {
 
     function extractMac(serviceName) {
         var hex = serviceName.replace("com.victronenergy.battery.bt", "").toLowerCase()
-        // Service names have no separators (e.g. btA4C138332459) — insert colons
         if (hex.indexOf(":") === -1 && hex.indexOf("_") === -1 && hex.length === 12)
             return hex.match(/.{2}/g).join(":")
-        // Older format used underscores
         return hex.replace(/_/g, ":")
     }
 
@@ -132,14 +118,13 @@ SwipeViewPage {
         var displayName = configName || ("Battery " + nextUnnamedIndex++)
         var serviceUid = "dbus/" + serviceName
 
-        // Determine insert position: named batteries in config order, unnamed appended
+        // Determine insert position: ordered batteries by batOrder, unnamed appended
         var insertIdx = batteryModel.count
-        if (nameMap[mac]) {
-            var configIdx = nameOrder.indexOf(mac)
+        var configIdx = batOrder.indexOf(mac)
+        if (configIdx >= 0) {
             insertIdx = 0
             for (var i = 0; i < batteryModel.count; i++) {
-                var existingMac = batteryModel.get(i).mac
-                var existingConfigIdx = nameOrder.indexOf(existingMac)
+                var existingConfigIdx = batOrder.indexOf(batteryModel.get(i).mac)
                 if (existingConfigIdx === -1 || existingConfigIdx < configIdx) {
                     insertIdx = i + 1
                 } else {
@@ -160,7 +145,6 @@ SwipeViewPage {
 
         discoveredServices[serviceName] = true
 
-        // Create binding component
         var component = Qt.createComponent(Qt.resolvedUrl("BatteryBinding.qml"))
         if (component.status === Component.Ready) {
             var binding = component.createObject(root, {
@@ -207,12 +191,10 @@ SwipeViewPage {
     // Battery model — populated by D-Bus discovery
     ListModel { id: batteryModel }
 
-    // Sizing — scaled for actual screen dimensions
+    // Sizing — scaled for 480x272 Touch 70 screen
     property int batteryCount: batteryModel.count
-    property int iconWidth: batteryCount <= 4 ? 40 : (batteryCount <= 6 ? 34 : 28)
-    property int iconHeight: batteryCount <= 4 ? 80 : (batteryCount <= 6 ? 68 : 56)
-    property int statFontSize: batteryCount <= 4 ? 10 : (batteryCount <= 6 ? 9 : 8)
-    property int socFontSize: batteryCount <= 4 ? 14 : (batteryCount <= 6 ? 12 : 11)
+    property int iconWidth: batteryCount <= 4 ? 62 : (batteryCount <= 6 ? 52 : 44)
+    property int iconHeight: batteryCount <= 4 ? 125 : (batteryCount <= 6 ? 106 : 88)
 
     // SOC color helper
     function socColor(soc) {
@@ -222,141 +204,133 @@ SwipeViewPage {
         return "#d32f2f"
     }
 
-    // Background
-    Rectangle {
-        anchors.fill: parent
-        color: "#1a1a2e"
-    }
-
-    // === TITLE BAR ===
-    Text {
-        id: titleBar
-        anchors.top: parent.top
+    // === MAIN CONTENT — vertically centered ===
+    Column {
+        id: mainContent
         anchors.horizontalCenter: parent.horizontalCenter
-        anchors.topMargin: 6
-        text: {
-            var stateLabel = root.bankState.charAt(0).toUpperCase() + root.bankState.slice(1)
-            return "\u26A1 Parallel Battery Bank \u2014 " + stateLabel
-        }
-        color: root.accentColor
-        font.pixelSize: 13
-        font.bold: true
-    }
+        anchors.verticalCenter: parent.verticalCenter
+        spacing: 4
 
-    // === BATTERY ROW ===
-    Row {
-        id: batteryRow
-        anchors.top: titleBar.bottom
-        anchors.topMargin: 8
-        anchors.horizontalCenter: parent.horizontalCenter
-        spacing: (root.width - batteryCount * (iconWidth + 16)) / (batteryCount + 1)
+        // === BATTERY ROW ===
+        Row {
+            id: batteryRow
+            anchors.horizontalCenter: parent.horizontalCenter
+            spacing: (root.width - batteryCount * (iconWidth + 20)) / (batteryCount + 1)
 
-        Repeater {
-            model: batteryModel
-            delegate: Column {
-                width: root.iconWidth + 16
-                spacing: 1
+            Repeater {
+                model: batteryModel
+                delegate: Column {
+                    width: root.iconWidth + 20
+                    spacing: 1
 
-                BatteryIcon {
-                    width: root.iconWidth
-                    height: root.iconHeight
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    soc: model.soc
-                    current: model.current
-                    state: root.bankState
-                    online: model.online
-                    socColorGreen: root.socColorGreen
-                    socColorYellow: root.socColorYellow
-                    socColorRed: root.socColorRed
-                }
+                    BatteryIcon {
+                        width: root.iconWidth
+                        height: root.iconHeight
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        soc: model.soc
+                        current: model.current
+                        state: root.bankState
+                        online: model.online
+                        socColorGreen: root.socColorGreen
+                        socColorYellow: root.socColorYellow
+                        socColorRed: root.socColorRed
+                    }
 
-                Text {
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    text: model.name
-                    color: "#4fc3f7"
-                    font.pixelSize: root.statFontSize + 1
-                    font.bold: true
-                }
+                    Text {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: model.name
+                        color: "#4fc3f7"
+                        font.pixelSize: root.fontBatNameSize
+                        font.bold: root.fontBatNameBold
+                    }
 
-                Text {
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    text: model.soc + "%"
-                    color: root.socColor(model.soc)
-                    font.pixelSize: root.socFontSize
-                    font.bold: true
-                }
+                    Text {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: model.soc + "%"
+                        color: root.socColor(model.soc)
+                        font.pixelSize: root.fontBatSocSize
+                        font.bold: root.fontBatSocBold
+                    }
 
-                Text {
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    text: model.voltage.toFixed(2) + "V \u00B7 " + model.current.toFixed(1) + "A"
-                    color: "#aaaaaa"
-                    font.pixelSize: root.statFontSize
-                }
+                    Text {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: model.voltage.toFixed(2) + "V \u00B7 " + model.current.toFixed(1) + "A"
+                        color: "#aaaaaa"
+                        font.pixelSize: root.fontBatStatsSize
+                        font.bold: root.fontBatStatsBold
+                    }
 
-                Text {
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    text: model.temperature + "\u00B0C \u00B7 \u0394V " + model.cellDiff.toFixed(2)
-                    color: "#aaaaaa"
-                    font.pixelSize: root.statFontSize
-                }
+                    Text {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: model.temperature + "\u00B0C \u00B7 \u0394V " + model.cellDiff.toFixed(2)
+                        color: "#aaaaaa"
+                        font.pixelSize: root.fontBatStatsSize
+                        font.bold: root.fontBatStatsBold
+                    }
 
-                Text {
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    text: model.cycles + " cycles"
-                    color: "#aaaaaa"
-                    font.pixelSize: root.statFontSize
+                    Text {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: model.cycles + " cycles"
+                        color: "#aaaaaa"
+                        font.pixelSize: root.fontBatStatsSize
+                        font.bold: root.fontBatStatsBold
+                    }
                 }
             }
         }
-    }
 
-    // === SEPARATOR ===
-    Rectangle {
-        id: separator
-        anchors.top: batteryRow.bottom
-        anchors.topMargin: 8
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.leftMargin: 12
-        anchors.rightMargin: 12
-        height: 1
-        color: root.accentColor
-    }
-
-    // === BANK AGGREGATE ROW ===
-    Row {
-        id: aggregateRow
-        anchors.top: separator.bottom
-        anchors.topMargin: 6
-        anchors.horizontalCenter: parent.horizontalCenter
-        spacing: 20
-
-        Column {
-            spacing: 1
-            Text { text: "BANK SOC"; color: "#888888"; font.pixelSize: 9; anchors.horizontalCenter: parent.horizontalCenter }
-            Text { text: root.bankSoc + "%"; color: root.socColor(root.bankSoc); font.pixelSize: 18; font.bold: true; anchors.horizontalCenter: parent.horizontalCenter }
+        // === SEPARATOR ===
+        Rectangle {
+            width: root.width - 24
+            height: 1
+            color: root.accentColor
+            anchors.horizontalCenter: parent.horizontalCenter
         }
 
-        Column {
-            spacing: 1
-            Text { text: "VOLTAGE"; color: "#888888"; font.pixelSize: 9; anchors.horizontalCenter: parent.horizontalCenter }
-            Text { text: root.bankVoltage.toFixed(2) + "V"; color: "#ffffff"; font.pixelSize: 18; font.bold: true; anchors.horizontalCenter: parent.horizontalCenter }
-        }
+        // === BANK AGGREGATE ROW ===
+        Row {
+            id: aggregateRow
+            anchors.horizontalCenter: parent.horizontalCenter
+            spacing: 16
 
-        Column {
-            spacing: 1
-            Text { text: "CURRENT"; color: "#888888"; font.pixelSize: 9; anchors.horizontalCenter: parent.horizontalCenter }
-            Text { text: root.bankCurrent.toFixed(1) + "A"; color: root.accentColor; font.pixelSize: 18; font.bold: true; anchors.horizontalCenter: parent.horizontalCenter }
-        }
+            Column {
+                spacing: 1
+                Text {
+                    text: root.bankState.charAt(0).toUpperCase() + root.bankState.slice(1)
+                    color: root.accentColor
+                    font.pixelSize: root.fontBankValueSize
+                    font.bold: root.fontBankValueBold
+                    anchors.horizontalCenter: parent.horizontalCenter
+                }
+            }
 
-        Column {
-            spacing: 1
-            Text { text: "CAPACITY"; color: "#888888"; font.pixelSize: 9; anchors.horizontalCenter: parent.horizontalCenter }
-            Row {
-                anchors.horizontalCenter: parent.horizontalCenter
-                spacing: 0
-                Text { id: capText; text: Math.round(root.bankCapacity).toString(); color: "#ffffff"; font.pixelSize: 18; font.bold: true }
-                Text { text: " / " + Math.round(root.bankInstalledCapacity) + " Ah"; color: "#888888"; font.pixelSize: 11; anchors.baseline: capText.baseline }
+            Column {
+                spacing: 1
+                Text { text: "BANK SOC"; color: "#888888"; font.pixelSize: root.fontBankLabelSize; font.bold: root.fontBankLabelBold; anchors.horizontalCenter: parent.horizontalCenter }
+                Text { text: root.bankSoc + "%"; color: root.socColor(root.bankSoc); font.pixelSize: root.fontBankValueSize; font.bold: root.fontBankValueBold; anchors.horizontalCenter: parent.horizontalCenter }
+            }
+
+            Column {
+                spacing: 1
+                Text { text: "VOLTAGE"; color: "#888888"; font.pixelSize: root.fontBankLabelSize; font.bold: root.fontBankLabelBold; anchors.horizontalCenter: parent.horizontalCenter }
+                Text { text: root.bankVoltage.toFixed(2) + "V"; color: "#ffffff"; font.pixelSize: root.fontBankValueSize; font.bold: root.fontBankValueBold; anchors.horizontalCenter: parent.horizontalCenter }
+            }
+
+            Column {
+                spacing: 1
+                Text { text: "CURRENT"; color: "#888888"; font.pixelSize: root.fontBankLabelSize; font.bold: root.fontBankLabelBold; anchors.horizontalCenter: parent.horizontalCenter }
+                Text { text: root.bankCurrent.toFixed(1) + "A"; color: root.accentColor; font.pixelSize: root.fontBankValueSize; font.bold: root.fontBankValueBold; anchors.horizontalCenter: parent.horizontalCenter }
+            }
+
+            Column {
+                spacing: 1
+                Text { text: "CAPACITY"; color: "#888888"; font.pixelSize: root.fontBankLabelSize; font.bold: root.fontBankLabelBold; anchors.horizontalCenter: parent.horizontalCenter }
+                Row {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    spacing: 0
+                    Text { id: capText; text: Math.round(root.bankCapacity).toString(); color: "#ffffff"; font.pixelSize: root.fontBankValueSize; font.bold: root.fontBankValueBold }
+                    Text { text: " / " + Math.round(root.bankInstalledCapacity) + " Ah"; color: "#888888"; font.pixelSize: root.fontBankLabelSize + 2; anchors.baseline: capText.baseline }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Generate `ConfigData.qml` from `config.ini` during install — workaround for XHR `file://` being blocked in GUI
- Bind aggregate from discovery loop + `/Soc` fallback (was watching nonexistent `/ProductName`)
- Replace `Array.isArray()` with `.length` check for QVariantList compatibility
- Icons 56% larger (62x125 for 4 batteries), vertically centered layout
- Configurable font sizes/weights: `FONT_BAT_NAME`, `FONT_BAT_SOC`, `FONT_BAT_STATS`, `FONT_BANK_LABEL`, `FONT_BANK_VALUE`
- Remove custom `#1a1a2e` background — inherit SwipeViewPage default to match carousel
- Restore `BT_NAMES` with `MAC=Name` format for persistent naming + render order
- Remove title bar, move state label to bank aggregate row

## Test plan

- [ ] Set `BT_NAMES` in config.ini with MAC=Name pairs
- [ ] Run `install.sh` — verify `ConfigData.qml` generated in `/data/venus-btbattery-gui/qml/`
- [ ] Battery names from config appear on screen
- [ ] Battery render order matches config order
- [ ] Bank aggregate row shows live SOC/voltage/current/capacity
- [ ] Background matches other carousel pages
- [ ] Font sizes adjustable via config.ini

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)
