### PR TITLE
chore: add default BT_NAMES, remove name length limit

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,9 +1,9 @@
 [GUI]
-# Map MAC addresses to display names (6 char max per name)
+# Map MAC addresses to display names
 # Format: MAC=Name pairs, comma-separated
 # Batteries render in the order listed here; unlisted batteries appended after
 # Example: 70:3e:97:08:00:62=Bat A,a4:c1:38:xx:xx:xx=Bat B
-BT_NAMES =
+BT_NAMES = a5:c2:37:4f:22:77=LiFePO4 A,a4:c1:38:33:24:59=LiFePO4 B,a4:c1:38:33:3d:cc=LiFePO4 C,a4:c1:38:33:20:0d=LiFePO4 D
 
 # SOC color thresholds (percentage)
 # Green: SOC >= this value

--- a/install.sh
+++ b/install.sh
@@ -142,7 +142,7 @@ with open(config_path) as f:
                     continue
                 mac, name = pair.split("=", 1)
                 mac = mac.strip().lower()
-                name = name.strip()[:6]
+                name = name.strip()
                 bt_names[mac] = name
                 bat_order.append(mac)
         elif key in key_map:


### PR DESCRIPTION
## Summary

- Add default `BT_NAMES` for the 4 EnjoyBot batteries (LiFePO4 A–D)
- Remove 6-char name truncation — names like "LiFePO4 A" now supported

## Test plan

- [ ] Verify battery names render correctly on screen

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)