### PR TITLE
fix: layout polish — font defaults, spacing, separator width

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -24,11 +24,11 @@ FONT_BAT_NAME_BOLD = true
 FONT_BAT_SOC_SIZE = 20
 FONT_BAT_SOC_BOLD = true
 # Battery stats (voltage, current, temp, cycles)
-FONT_BAT_STATS_SIZE = 14
+FONT_BAT_STATS_SIZE = 16
 FONT_BAT_STATS_BOLD = false
 # Bank aggregate labels (BANK SOC, VOLTAGE, etc.)
-FONT_BANK_LABEL_SIZE = 10
+FONT_BANK_LABEL_SIZE = 12
 FONT_BANK_LABEL_BOLD = false
 # Bank aggregate values
-FONT_BANK_VALUE_SIZE = 18
+FONT_BANK_VALUE_SIZE = 20
 FONT_BANK_VALUE_BOLD = true

--- a/qml/PageBatteryParallelOverview.qml
+++ b/qml/PageBatteryParallelOverview.qml
@@ -21,11 +21,11 @@ SwipeViewPage {
     property bool fontBatNameBold: true
     property int fontBatSocSize: 20
     property bool fontBatSocBold: true
-    property int fontBatStatsSize: 14
+    property int fontBatStatsSize: 16
     property bool fontBatStatsBold: false
-    property int fontBankLabelSize: 10
+    property int fontBankLabelSize: 12
     property bool fontBankLabelBold: false
-    property int fontBankValueSize: 18
+    property int fontBankValueSize: 20
     property bool fontBankValueBold: true
 
     Component.onCompleted: loadConfig()
@@ -236,6 +236,8 @@ SwipeViewPage {
                         socColorRed: root.socColorRed
                     }
 
+                    Item { width: 1; height: 4 }
+
                     Text {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: model.name
@@ -280,12 +282,14 @@ SwipeViewPage {
         }
 
         // === SEPARATOR ===
+        Item { width: 1; height: 4 }
         Rectangle {
-            width: root.width - 24
+            width: batteryRow.width
             height: 1
             color: root.accentColor
             anchors.horizontalCenter: parent.horizontalCenter
         }
+        Item { width: 1; height: 4 }
 
         // === BANK AGGREGATE ROW ===
         Row {


### PR DESCRIPTION
## Summary

- Update font defaults to match on-device tuning (stats=16, bank label=12, bank value=20)
- Add 4px spacer between battery icon and name label
- Constrain separator to battery row width (was full screen)
- Add 4px padding above and below separator

## Test plan

- [ ] Verify spacing between icon and name label
- [ ] Verify separator width matches battery row
- [ ] Verify padding above/below separator

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)