### PR TITLE
Fix: force VeQuickItem re-subscription to keep data fresh

### DIFF
--- a/qml/AggregateBinding.qml
+++ b/qml/AggregateBinding.qml
@@ -6,15 +6,61 @@ Item {
 
     required property string serviceUid
 
-    property real soc: socItem.valid ? socItem.value : 0
-    property real voltage: voltageItem.valid ? voltageItem.value : 0
-    property real current: currentItem.valid ? currentItem.value : 0
-    property real capacity: capacityItem.valid ? capacityItem.value : 0
-    property real installedCapacity: installedCapacityItem.valid ? installedCapacityItem.value : 0
+    // Cached values — updated by explicit handlers so they survive
+    // the brief invalid window during uid-toggle refresh
+    property real soc: 0
+    property real voltage: 0
+    property real current: 0
+    property real capacity: 0
+    property real installedCapacity: 0
 
-    VeQuickItem { id: socItem; uid: root.serviceUid + "/Soc" }
-    VeQuickItem { id: voltageItem; uid: root.serviceUid + "/Dc/0/Voltage" }
-    VeQuickItem { id: currentItem; uid: root.serviceUid + "/Dc/0/Current" }
-    VeQuickItem { id: capacityItem; uid: root.serviceUid + "/Capacity" }
-    VeQuickItem { id: installedCapacityItem; uid: root.serviceUid + "/InstalledCapacity" }
+    VeQuickItem {
+        id: socItem
+        uid: root.serviceUid + "/Soc"
+        onValueChanged: if (valid) root.soc = value
+        onValidChanged: if (valid && value !== undefined) root.soc = value
+    }
+    VeQuickItem {
+        id: voltageItem
+        uid: root.serviceUid + "/Dc/0/Voltage"
+        onValueChanged: if (valid) root.voltage = value
+        onValidChanged: if (valid && value !== undefined) root.voltage = value
+    }
+    VeQuickItem {
+        id: currentItem
+        uid: root.serviceUid + "/Dc/0/Current"
+        onValueChanged: if (valid) root.current = value
+        onValidChanged: if (valid && value !== undefined) root.current = value
+    }
+    VeQuickItem {
+        id: capacityItem
+        uid: root.serviceUid + "/Capacity"
+        onValueChanged: if (valid) root.capacity = value
+        onValidChanged: if (valid && value !== undefined) root.capacity = value
+    }
+    VeQuickItem {
+        id: installedCapacityItem
+        uid: root.serviceUid + "/InstalledCapacity"
+        onValueChanged: if (valid) root.installedCapacity = value
+        onValidChanged: if (valid && value !== undefined) root.installedCapacity = value
+    }
+
+    // Force VeQuickItems to re-subscribe by toggling uid off and back on.
+    // Works around live MQTT subscriptions not being maintained for
+    // VeQuickItems inside file://-loaded SwipeViewPages.
+    function forceRefresh() {
+        var items = [socItem, voltageItem, currentItem, capacityItem, installedCapacityItem]
+        for (var i = 0; i < items.length; i++) {
+            var u = items[i].uid
+            items[i].uid = ""
+            items[i].uid = u
+        }
+    }
+
+    Timer {
+        interval: 5000
+        running: true
+        repeat: true
+        onTriggered: root.forceRefresh()
+    }
 }

--- a/qml/BatteryBinding.qml
+++ b/qml/BatteryBinding.qml
@@ -30,28 +30,40 @@ Item {
     }
 
     VeQuickItem {
+        id: socItem
         uid: root.serviceUid + "/Soc"
         onValueChanged: if (valid) root.updateModel("soc", Math.round(value))
+        onValidChanged: if (valid && value !== undefined) root.updateModel("soc", Math.round(value))
     }
     VeQuickItem {
+        id: voltageItem
         uid: root.serviceUid + "/Dc/0/Voltage"
         onValueChanged: if (valid) root.updateModel("voltage", value)
+        onValidChanged: if (valid && value !== undefined) root.updateModel("voltage", value)
     }
     VeQuickItem {
+        id: currentItem
         uid: root.serviceUid + "/Dc/0/Current"
         onValueChanged: if (valid) root.updateModel("current", value)
+        onValidChanged: if (valid && value !== undefined) root.updateModel("current", value)
     }
     VeQuickItem {
+        id: temperatureItem
         uid: root.serviceUid + "/Dc/0/Temperature"
         onValueChanged: if (valid) root.updateModel("temperature", Math.round(value))
+        onValidChanged: if (valid && value !== undefined) root.updateModel("temperature", Math.round(value))
     }
     VeQuickItem {
+        id: cellDiffItem
         uid: root.serviceUid + "/Voltages/Diff"
         onValueChanged: if (valid) root.updateModel("cellDiff", value)
+        onValidChanged: if (valid && value !== undefined) root.updateModel("cellDiff", value)
     }
     VeQuickItem {
+        id: cyclesItem
         uid: root.serviceUid + "/History/ChargeCycles"
         onValueChanged: if (valid) root.updateModel("cycles", value)
+        onValidChanged: if (valid && value !== undefined) root.updateModel("cycles", value)
     }
 
     // Issue 3 fix: Disconnection handling
@@ -67,5 +79,27 @@ Item {
             var idx = root.findModelIndex()
             if (idx >= 0) root.batteryModel.setProperty(idx, "online", valid && value === 1)
         }
+    }
+
+    // Force VeQuickItems to re-subscribe by toggling uid off and back on.
+    // Works around live MQTT subscriptions not being maintained for
+    // VeQuickItems inside file://-loaded SwipeViewPages.
+    // The model retains last-good values during the brief invalid window,
+    // so no visual flicker occurs.
+    function forceRefresh() {
+        var items = [socItem, voltageItem, currentItem,
+                     temperatureItem, cellDiffItem, cyclesItem, connectedItem]
+        for (var i = 0; i < items.length; i++) {
+            var u = items[i].uid
+            items[i].uid = ""
+            items[i].uid = u
+        }
+    }
+
+    Timer {
+        interval: 5000
+        running: true
+        repeat: true
+        onTriggered: root.forceRefresh()
     }
 }


### PR DESCRIPTION
## Summary

- Force VeQuickItem re-subscription every 5s by toggling uid off/on, working around gui-v2 not maintaining live MQTT subscriptions for `file://`-loaded pages
- Add `onValidChanged` handlers to all data VeQuickItems to catch reconnection events
- Switch AggregateBinding from reactive property bindings to cached values so they survive the brief invalid window during uid-toggle refresh

Closes #26

## Test plan

- [ ] Deploy updated QML files to Cerbo and restart GUI (`svc -t /service/gui`)
- [ ] Verify individual battery values (voltage, current, SOC, temp) update within 5 seconds
- [ ] Verify bank aggregate row (bank SOC, voltage, current, capacity) updates
- [ ] Start/stop alternator and confirm current changes are reflected
- [ ] Navigate away from battery page and back — values should continue updating
- [ ] Check for visual flicker during refresh cycles (should be none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)