### PR TITLE
Show soft reset and reconnect counters per battery

### DIFF
--- a/qml/BatteryBinding.qml
+++ b/qml/BatteryBinding.qml
@@ -53,6 +53,14 @@ Item {
         uid: root.serviceUid + "/History/ChargeCycles"
         onValueChanged: if (valid) root.updateModel("cycles", value)
     }
+    VeQuickItem {
+        uid: root.serviceUid + "/Info/SoftResetCount"
+        onValueChanged: if (valid) root.updateModel("softResets", value)
+    }
+    VeQuickItem {
+        uid: root.serviceUid + "/Info/ReconnectCount"
+        onValueChanged: if (valid) root.updateModel("reconnects", value)
+    }
 
     // Issue 3 fix: Disconnection handling
     // Watch /Connected to detect service going offline

--- a/qml/PageBatteryParallelOverview.qml
+++ b/qml/PageBatteryParallelOverview.qml
@@ -140,6 +140,7 @@ SwipeViewPage {
             serviceUid: serviceUid,
             soc: 0, voltage: 0, current: 0,
             temperature: 0, cellDiff: 0, cycles: 0,
+            softResets: 0, reconnects: 0,
             online: true
         })
 
@@ -277,6 +278,14 @@ SwipeViewPage {
                         font.pixelSize: root.fontBatStatsSize
                         font.bold: root.fontBatStatsBold
                     }
+
+                    Text {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: "S: " + model.softResets + " / R: " + model.reconnects
+                        color: "#666666"
+                        font.pixelSize: root.fontBatStatsSize - 2
+                        font.bold: root.fontBatStatsBold
+                    }
                 }
             }
         }
@@ -333,7 +342,7 @@ SwipeViewPage {
                     anchors.horizontalCenter: parent.horizontalCenter
                     spacing: 0
                     Text { id: capText; text: Math.round(root.bankCapacity).toString(); color: "#ffffff"; font.pixelSize: root.fontBankValueSize; font.bold: root.fontBankValueBold }
-                    Text { text: " / " + Math.round(root.bankInstalledCapacity) + " Ah"; color: "#888888"; font.pixelSize: root.fontBankLabelSize + 2; anchors.baseline: capText.baseline }
+                    Text { text: " / " + Math.round(root.bankInstalledCapacity) + " Ah"; color: "#888888"; font.pixelSize: root.fontBankLabelSize + 2; font.bold: root.fontBankLabelBold; anchors.baseline: capText.baseline }
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Subscribe to `/Info/SoftResetCount` and `/Info/ReconnectCount` in BatteryBinding
- Display `S: N / R: N` at the bottom of each battery's info stack
- Soft resets first, reconnects second
- Fix missing `font.bold` on capacity denominator text

Closes #28

## Test plan

- [ ] Deploy to Cerbo with updated dbus-btbattery and verify counters appear
- [ ] Counters should show 0/0 initially and increment if recovery events occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)