### PR TITLE
Fix visual tweaks: counter line style, font sizes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -102,10 +102,10 @@ output_path = sys.argv[2]
 vals = {
     "socColorGreen": 60, "socColorYellow": 20, "socColorRed": 10,
     "maxBatteries": 8,
-    "fontBatNameSize": 13, "fontBatNameBold": True,
+    "fontBatNameSize": 14, "fontBatNameBold": True,
     "fontBatSocSize": 20, "fontBatSocBold": True,
     "fontBatStatsSize": 14, "fontBatStatsBold": False,
-    "fontBankLabelSize": 10, "fontBankLabelBold": False,
+    "fontBankLabelSize": 11, "fontBankLabelBold": False,
     "fontBankValueSize": 18, "fontBankValueBold": True,
 }
 bt_names = {}   # mac -> name

--- a/qml/PageBatteryParallelOverview.qml
+++ b/qml/PageBatteryParallelOverview.qml
@@ -17,13 +17,13 @@ SwipeViewPage {
     property var batOrder: []    // MAC strings in config order
 
     // Font config
-    property int fontBatNameSize: 13
+    property int fontBatNameSize: 14
     property bool fontBatNameBold: true
     property int fontBatSocSize: 20
     property bool fontBatSocBold: true
     property int fontBatStatsSize: 16
     property bool fontBatStatsBold: false
-    property int fontBankLabelSize: 13
+    property int fontBankLabelSize: 14
     property bool fontBankLabelBold: false
     property int fontBankValueSize: 20
     property bool fontBankValueBold: true
@@ -282,8 +282,8 @@ SwipeViewPage {
                     Text {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: "S: " + model.softResets + " / R: " + model.reconnects
-                        color: "#666666"
-                        font.pixelSize: root.fontBatStatsSize - 2
+                        color: "#aaaaaa"
+                        font.pixelSize: root.fontBatStatsSize
                         font.bold: root.fontBatStatsBold
                     }
                 }


### PR DESCRIPTION
## Summary

- Match counter line color and size to other battery stat lines
- Bump battery name font size +1 (13→14)
- Bump bank label font size +1 (10→11 in install.sh, 13→14 in QML default)

Closes #30

## Test plan

- [ ] Deploy QML and verify counter line matches other stats visually
- [ ] Battery names slightly larger
- [ ] Bank section labels (BANK SOC, VOLTAGE, etc.) slightly larger

🤖 Generated with [Claude Code](https://claude.com/claude-code)