### PR TITLE
Fix install.sh when run from install directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,12 +40,17 @@ if [ -f "$SCRIPT_DIR/config.ini" ]; then
 fi
 
 # Copy files to /data (persists across firmware upgrades)
+# When running from INSTALL_DIR itself, skip copies that would be src==dst
 echo "Installing to $INSTALL_DIR..."
 mkdir -p "$INSTALL_DIR/qml"
-cp "$SCRIPT_DIR/config.ini" "$INSTALL_DIR/"
-cp "$SCRIPT_DIR/qml/"*.qml "$INSTALL_DIR/qml/"
-cp "$SCRIPT_DIR/install.sh" "$INSTALL_DIR/"
-cp "$SCRIPT_DIR/uninstall.sh" "$INSTALL_DIR/"
+if [ "$(realpath "$SCRIPT_DIR")" != "$(realpath "$INSTALL_DIR")" ]; then
+    cp "$SCRIPT_DIR/config.ini" "$INSTALL_DIR/"
+    cp "$SCRIPT_DIR/qml/"*.qml "$INSTALL_DIR/qml/"
+    cp "$SCRIPT_DIR/install.sh" "$INSTALL_DIR/"
+    cp "$SCRIPT_DIR/uninstall.sh" "$INSTALL_DIR/"
+else
+    echo "Running from install directory, skipping file copy."
+fi
 
 # Write the SwipePageModel patch script
 cat > "$INSTALL_DIR/patch_swipe_model.py" << 'PYEOF'


### PR DESCRIPTION
## Summary

Skip file copy when SCRIPT_DIR == INSTALL_DIR to avoid `cp: same file` error that aborts the script under `set -e`.

Closes #34

## Test plan

- [ ] Run `bash /data/venus-btbattery-gui/install.sh` from the Cerbo — should complete without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)