### PR TITLE
Fix bank label visibility, capacity size, and SOC rounding

### DIFF
--- a/qml/PageBatteryParallelOverview.qml
+++ b/qml/PageBatteryParallelOverview.qml
@@ -169,7 +169,8 @@ SwipeViewPage {
     }
 
     // Bank aggregate — bound to aggregate service
-    property int bankSoc: aggregateBinding ? Math.round(aggregateBinding.soc) : 0
+    // Match VenusOS convention: don't round up to 100% unless truly ≥99.9
+    property int bankSoc: aggregateBinding ? (aggregateBinding.soc >= 99.9 ? 100 : Math.floor(aggregateBinding.soc)) : 0
     property real bankVoltage: aggregateBinding ? aggregateBinding.voltage : 0
     property real bankCurrent: aggregateBinding ? aggregateBinding.current : 0
     property real bankCapacity: aggregateBinding ? aggregateBinding.capacity : 0


### PR DESCRIPTION
## Summary

- Change bank label color #888888 → #aaaaaa for readability
- Change capacity denominator to fontBankValueSize to match numerator
- Match VenusOS SOC convention: floor below 99.9, only show 100% at ≥99.9

Closes #32
Closes #36

## Test plan

- [ ] Bank labels easier to read
- [ ] Capacity denominator same size as numerator
- [ ] With 2×99% + 2×100% batteries, bank SOC shows 99% not 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)