### PR TITLE
Fix GUI service name in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -231,9 +231,15 @@ RCEOF
 
 echo "rc.local updated."
 
-# Restart GUI
+# Restart GUI (service name varies by VenusOS version)
 echo "Restarting GUI..."
-svc -t /service/gui 2>/dev/null || echo "Note: GUI restart skipped (not on VenusOS)."
+if [ -d /service/start-gui ]; then
+    svc -t /service/start-gui
+elif [ -d /service/gui ]; then
+    svc -t /service/gui
+else
+    echo "Note: GUI restart skipped (not on VenusOS)."
+fi
 
 echo ""
 echo "=== Installation complete ==="


### PR DESCRIPTION
## Summary

- Check for `/service/start-gui` (Cerbo GX) before falling back to `/service/gui`
- Previously the restart silently failed, requiring a manual reboot

Closes #38

## Test plan

- [ ] Run `bash /data/venus-btbattery-gui/install.sh` on Cerbo — GUI should actually restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)