### PR TITLE
Increase battery icon size and bump font sizes

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -18,17 +18,17 @@ MAX_BATTERIES = 8
 
 # Font sizes (pixels) and bold (true/false)
 # Battery name label
-FONT_BAT_NAME_SIZE = 13
+FONT_BAT_NAME_SIZE = 15
 FONT_BAT_NAME_BOLD = true
 # Battery SOC percentage
-FONT_BAT_SOC_SIZE = 20
+FONT_BAT_SOC_SIZE = 21
 FONT_BAT_SOC_BOLD = true
 # Battery stats (voltage, current, temp, cycles)
-FONT_BAT_STATS_SIZE = 16
+FONT_BAT_STATS_SIZE = 17
 FONT_BAT_STATS_BOLD = false
 # Bank aggregate labels (BANK SOC, VOLTAGE, etc.)
-FONT_BANK_LABEL_SIZE = 13
+FONT_BANK_LABEL_SIZE = 15
 FONT_BANK_LABEL_BOLD = false
 # Bank aggregate values
-FONT_BANK_VALUE_SIZE = 20
+FONT_BANK_VALUE_SIZE = 21
 FONT_BANK_VALUE_BOLD = true

--- a/install.sh
+++ b/install.sh
@@ -107,11 +107,11 @@ output_path = sys.argv[2]
 vals = {
     "socColorGreen": 60, "socColorYellow": 20, "socColorRed": 10,
     "maxBatteries": 8,
-    "fontBatNameSize": 14, "fontBatNameBold": True,
-    "fontBatSocSize": 20, "fontBatSocBold": True,
-    "fontBatStatsSize": 14, "fontBatStatsBold": False,
-    "fontBankLabelSize": 11, "fontBankLabelBold": False,
-    "fontBankValueSize": 18, "fontBankValueBold": True,
+    "fontBatNameSize": 15, "fontBatNameBold": True,
+    "fontBatSocSize": 21, "fontBatSocBold": True,
+    "fontBatStatsSize": 15, "fontBatStatsBold": False,
+    "fontBankLabelSize": 12, "fontBankLabelBold": False,
+    "fontBankValueSize": 19, "fontBankValueBold": True,
 }
 bt_names = {}   # mac -> name
 bat_order = []  # macs in config order

--- a/qml/PageBatteryParallelOverview.qml
+++ b/qml/PageBatteryParallelOverview.qml
@@ -17,15 +17,15 @@ SwipeViewPage {
     property var batOrder: []    // MAC strings in config order
 
     // Font config
-    property int fontBatNameSize: 14
+    property int fontBatNameSize: 15
     property bool fontBatNameBold: true
-    property int fontBatSocSize: 20
+    property int fontBatSocSize: 21
     property bool fontBatSocBold: true
-    property int fontBatStatsSize: 16
+    property int fontBatStatsSize: 17
     property bool fontBatStatsBold: false
-    property int fontBankLabelSize: 14
+    property int fontBankLabelSize: 15
     property bool fontBankLabelBold: false
-    property int fontBankValueSize: 20
+    property int fontBankValueSize: 21
     property bool fontBankValueBold: true
 
     Component.onCompleted: loadConfig()
@@ -195,8 +195,8 @@ SwipeViewPage {
 
     // Sizing — scaled for 480x272 Touch 70 screen
     property int batteryCount: batteryModel.count
-    property int iconWidth: batteryCount <= 4 ? 62 : (batteryCount <= 6 ? 52 : 44)
-    property int iconHeight: batteryCount <= 4 ? 125 : (batteryCount <= 6 ? 106 : 88)
+    property int iconWidth: batteryCount <= 4 ? 71 : (batteryCount <= 6 ? 60 : 51)
+    property int iconHeight: batteryCount <= 4 ? 144 : (batteryCount <= 6 ? 122 : 101)
 
     // SOC color helper
     function socColor(soc) {
@@ -211,7 +211,7 @@ SwipeViewPage {
         id: mainContent
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.verticalCenter: parent.verticalCenter
-        spacing: 4
+        spacing: 2
 
         // === BATTERY ROW ===
         Row {
@@ -223,7 +223,7 @@ SwipeViewPage {
                 model: batteryModel
                 delegate: Column {
                     width: root.iconWidth + 20
-                    spacing: 1
+                    spacing: 0
 
                     BatteryIcon {
                         width: root.iconWidth
@@ -238,7 +238,7 @@ SwipeViewPage {
                         socColorRed: root.socColorRed
                     }
 
-                    Item { width: 1; height: 4 }
+                    Item { width: 1; height: 2 }
 
                     Text {
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -292,14 +292,14 @@ SwipeViewPage {
         }
 
         // === SEPARATOR ===
-        Item { width: 1; height: 4 }
+        Item { width: 1; height: 2 }
         Rectangle {
             width: batteryRow.width
             height: 1
             color: root.accentColor
             anchors.horizontalCenter: parent.horizontalCenter
         }
-        Item { width: 1; height: 4 }
+        Item { width: 1; height: 2 }
 
         // === BANK AGGREGATE ROW ===
         Row {


### PR DESCRIPTION
## Summary

- Battery icons ~15% larger across all battery count tiers
- All font sizes +1 increment (QML defaults, install.sh defaults, config.ini)
- Spacing reduced to compensate and prevent overflow

Closes #40

## Test plan

- [ ] Battery icons visibly larger
- [ ] All text slightly larger and readable
- [ ] No content overflow or clipping on Touch 70 screen
- [ ] Bank section still fits below separator

🤖 Generated with [Claude Code](https://claude.com/claude-code)